### PR TITLE
Corrupted storages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 [workspace.package]
 license = "MIT"
 version = "0.4.10"
-edition = "2021"
+edition = "2024"
 repository = "https://github.com/UniqueNetwork/chainql"
 
 [workspace.metadata.crane]

--- a/cmds/chainql/src/main.rs
+++ b/cmds/chainql/src/main.rs
@@ -10,9 +10,10 @@ use tracing_subscriber::{
 };
 use tracing::Level;
 
-#[derive(ValueEnum, Clone, Copy)]
+#[derive(Clone, Copy, Default, ValueEnum)]
 enum CorruptedStorageStrategy {
 	/// Return error when storage decoding fails.
+	#[default]
 	RaiseError,
 
 	/// Use default values from metadata
@@ -29,7 +30,7 @@ struct Options {
 	/// Please contact the developer to fix the storage.
 	///
 	/// There's no guarantee that the chain will start and function correctly with corrupted data.
-	#[arg(long, default_value = "raise-error")]
+	#[arg(long, value_enum, default_value_t)]
 	corrupted_storage_strategy: CorruptedStorageStrategy,
 }
 

--- a/cmds/chainql/src/main.rs
+++ b/cmds/chainql/src/main.rs
@@ -1,6 +1,6 @@
 use std::{io::Read, process};
 
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use jrsonnet_cli::{InputOpts, MiscOpts, StdOpts, TlaOpts, TraceOpts};
 use jrsonnet_evaluator::{apply_tla, bail, error::Result, manifest::JsonFormat, State};
 use tokio::runtime::Handle;
@@ -10,9 +10,34 @@ use tracing_subscriber::{
 };
 use tracing::Level;
 
+#[derive(ValueEnum, Clone, Copy)]
+enum CorruptedStorageStrategy {
+	/// Return error when storage decoding fails.
+	RaiseError,
+
+	/// Use default values from metadata
+	/// with warning about every corrupted storage.
+	UseDefault,
+}
+
+#[derive(Parser, Clone, Copy)]
+#[clap(next_help_heading = "OPTIONS")]
+struct Options {
+	/// This flag specifies how chainql will handle decoding errors.
+	///
+	/// If you needed the flag, you've found a bug.
+	/// Please contact the developer to fix the storage.
+	///
+	/// There's no guarantee that the chain will start and function correctly with corrupted data.
+	#[arg(long, default_value = "raise-error")]
+	corrupted_storage_strategy: CorruptedStorageStrategy,
+}
+
 /// chainql
 #[derive(Parser)]
 struct Opts {
+	#[command(flatten)]
+	options: Options,
 	#[clap(flatten)]
 	input: InputOpts,
 	#[clap(flatten)]
@@ -26,6 +51,7 @@ struct Opts {
 	#[clap(long, short = 'S')]
 	string: bool,
 }
+
 /// Set up Jrsonnet.
 fn main_jrsonnet(opts: Opts) -> Result<String> {
 	let indicatif_layer = IndicatifLayer::new()

--- a/crates/chainql-core/src/lib.rs
+++ b/crates/chainql-core/src/lib.rs
@@ -483,7 +483,7 @@ where
 	if let Err(err) = &value
 		&& use_default_for_corrupted_storages
 	{
-		warn!("Storage {name} is corrupted. Default values will be used. Error: {err}");
+		warn!("storage {name} is corrupted, default values will be used: {err}");
 
 		value = if let Some(default) = default {
 			decode_value(&mut default.as_ref(), reg, typ, compact)

--- a/crates/chainql-core/src/lib.rs
+++ b/crates/chainql-core/src/lib.rs
@@ -525,7 +525,7 @@ where
 						let mut obj = ObjValueBuilder::new();
 						let val =
 							decode_obj_value(dec, reg, &var.fields, compact).map_err(|err| {
-								runtime_error!("broken variant {}: {}", var.name, err)
+								runtime_error!("failed to decode {} variant: {}", var.name, err)
 							})?;
 						obj.field(var.name.as_str()).try_value(val)?;
 

--- a/crates/chainql-core/src/rebuild.rs
+++ b/crates/chainql-core/src/rebuild.rs
@@ -74,7 +74,7 @@ fn rebuild_inner(
 		let data = ObjValue::from_untyped(data)?;
 		handled_prefixes.push(pallet_prefix);
 		out.push_prefix(&pallet_prefix);
-		eprintln!("rebuilding pallet {}", storage.prefix);
+		tracing::info!("rebuilding pallet {}", storage.prefix);
 		rebuild_pallet(data, out, &meta.types, storage)
 			.with_description(|| format!("pallet <{key}> rebuild"))?;
 		out.pop_prefix()
@@ -137,7 +137,7 @@ fn rebuild_storage_entry(
 			key,
 			value,
 		} => {
-			eprintln!("rebuilding storage {}", meta.name);
+			tracing::info!("rebuilding storage {}", meta.name);
 			let keys = normalize_storage_map_keys(reg, *key, hashers)?;
 			rebuild_storage(data, out, reg, &keys, *value, 0)
 		}

--- a/crates/chainql-core/src/rebuild.rs
+++ b/crates/chainql-core/src/rebuild.rs
@@ -4,9 +4,10 @@ use frame_metadata::{
 	PalletStorageMetadata, RuntimeMetadataV14, StorageEntryMetadata, StorageEntryType,
 	StorageHasher,
 };
-use jrsonnet_evaluator::{bail, runtime_error, typed::Typed, ObjValue, Result, ResultExt, Val};
-use scale_info::{form::PortableForm, interner::UntrackedSymbol, PortableRegistry};
+use jrsonnet_evaluator::{ObjValue, Result, ResultExt, Val, bail, typed::Typed};
+use scale_info::{PortableRegistry, form::PortableForm, interner::UntrackedSymbol};
 use sp_core::twox_128;
+use tracing::info;
 
 use crate::{encode_single_key, encode_value, hex::Hex, normalize_storage_map_keys};
 
@@ -74,7 +75,7 @@ fn rebuild_inner(
 		let data = ObjValue::from_untyped(data)?;
 		handled_prefixes.push(pallet_prefix);
 		out.push_prefix(&pallet_prefix);
-		tracing::info!("rebuilding pallet {}", storage.prefix);
+		info!("rebuilding pallet {}", storage.prefix);
 		rebuild_pallet(data, out, &meta.types, storage)
 			.with_description(|| format!("pallet <{key}> rebuild"))?;
 		out.pop_prefix()
@@ -106,16 +107,7 @@ fn rebuild_pallet(
 		};
 		let storage_prefix = twox_128(entry.name.as_bytes());
 
-		let data = match data {
-			Ok(data) => data,
-			Err(err) => {
-				return Err(runtime_error!(
-					"failed to rebuild storage {key}: {}",
-					// remove a lot of nested "runtime error" messages
-					err.to_string().replace("runtime error: ", "")
-				));
-			}
-		};
+		let data = data.with_description(|| format!("storage entry <{key}> decode"))?;
 
 		handled_prefixes.push(storage_prefix);
 		out.push_prefix(&storage_prefix);
@@ -147,7 +139,7 @@ fn rebuild_storage_entry(
 			key,
 			value,
 		} => {
-			tracing::info!("rebuilding storage {}", meta.name);
+			info!("rebuilding storage {}", meta.name);
 			let keys = normalize_storage_map_keys(reg, *key, hashers)?;
 			rebuild_storage(data, out, reg, &keys, *value, 0)
 		}


### PR DESCRIPTION
Blocked by https://github.com/UniqueNetwork/chainql/pull/11.

Adds an option to "repair" storage with a default value and significantly improves logging for decoding errors.